### PR TITLE
fixed js error

### DIFF
--- a/button-v5.php
+++ b/button-v5.php
@@ -232,7 +232,7 @@ class acf_field_button extends acf_field {
 				var vals = _.each(vars, function(placeholder)
 				{
 					var name = placeholder.substr(1, placeholder.length-2); // ignore opening and closing {brackets}
-					var val = $('input[name=' + name + ']').val();
+					var val = $('input[name="' + name + '"]').val();
 					url = url.replace(placeholder, val);
 				});
 


### PR DESCRIPTION
added quotes to fix js error when clicking button 
error was: Uncaught Error: Syntax error, unrecognized expression: input[name=acf[field_594abe1bf59a0]]